### PR TITLE
Standardized on camel-case for the PatternFly project name

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # patternfly-eng-release
-A set of release engineering scripts for PatternFly, Angular Patternfly, Patternfly Org, and RCUE
+A set of release engineering scripts for PatternFly, Angular PatternFly, PatternFly Org, and RCUE
 
 ## Builds
 
@@ -13,15 +13,15 @@ Where applicable to each repo, the scripts may clone a new GitHub repo, bump the
 
 The automated release build begins with the build/release/release-all.sh script. This script will push a custom release tag to the repo's master branch, which triggers Travis to run the build/release/build.sh script. Version bump changes are pushed back to the master branch. The version bump and generated build changes are pushed to master-dist and tagged (e.g., v3.15.0).
 
-Release builds are chained together by pushing a new custom release tag to the next repo. For example, if the Patternfly RE release is successful, Patternfly is built next. If the Patternfly release is successful, RCUE and Angular Patternfly are built simultaneously. If Angular is successful, Patternfly Org is released as well.
+Release builds are chained together by pushing a new custom release tag to the next repo. For example, if the PatternFly RE release is successful, PatternFly is built next. If the PatternFly release is successful, RCUE and Angular PatternFly are built simultaneously. If Angular is successful, PatternFly Org is released as well.
 
-Should a release build fail at any point, it can be fixed and restarted. For example, If Angular Patternfly fails, it can be restarted and the Patternfly Org release will follow. We don't necessarily need to bump the npm version number again or rebuild Patternfy. The npm publish is one of the last steps in the build.
+Should a release build fail at any point, it can be fixed and restarted. For example, If Angular PatternFly fails, it can be restarted and the PatternFly Org release will follow. We don't necessarily need to bump the npm version number again or rebuild Patternfy. The npm publish is one of the last steps in the build.
 
 Of course, we still have the ability to run the release manually using the build/release/release.sh script. In fact, the release build uses this script itself.
 
 ### build/release/release-all.sh
 
-This script is used to automate and chain releases together. For example, when the Patternfly RE release is complete, Patternfly is built next. When the Patternfly release is complete, the release processes for Angular Patternfly and RCUE are kicked off simultaneously. When the Angular Patternfly release is complete, Patternfly Org shall be released as well.
+This script is used to automate and chain releases together. For example, when the PatternFly RE release is complete, PatternFly is built next. When the PatternFly release is complete, the release processes for Angular PatternFly and RCUE are kicked off simultaneously. When the Angular PatternFly release is complete, PatternFly Org shall be released as well.
 
 Although there is no PR to deal with here, creating release notes is still a task which must be performed manually via GitHub.
 
@@ -36,7 +36,7 @@ Builds can only be stopped via the Travis CI.
 
 ### build/release/notify.sh
 
-This script will send community email to the Patternfly and Angular Patternfly mailling lists.
+This script will send community email to the PatternFly and Angular PatternFly mailling lists.
 
 After publishing a release notes via GitHub, this script will pull markup using GitHub APIs. The release note markup is then added to the body of the outgoing message.
 

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "license": "Apache-2.0",
   "dependencies": {},
   "devDependencies": {},
-  "description": "A set of release engineering scripts for PatternFly, Angular Patternfly, Patternfly Org, and RCUE.",
+  "description": "A set of release engineering scripts for PatternFly, Angular PatternFly, PatternFly Org, and RCUE.",
   "repository": {
     "type": "git",
     "url": "https://github.com/patternfly/patternfly-eng-release.git"

--- a/scripts/_build.sh
+++ b/scripts/_build.sh
@@ -45,11 +45,11 @@ cat <<- EEOOFF
     OPTIONS:
     h       Display this message (default)
     a       Angular PatternFly
-    e       Patternfly Eng Release
+    e       PatternFly Eng Release
     o       PatternFly Org
     p       PatternFly
     r       PatternFly RCUE
-    w       Patternfly Web Components
+    w       PatternFly Web Components
 
 EEOOFF
 }

--- a/scripts/_env.sh
+++ b/scripts/_env.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-# Build Patternfly templates using Jekyll
+# Build PatternFly templates using Jekyll
 export PF_PAGE_BUILDER=jekyll
 
 # Email used to notify users release is available

--- a/scripts/release/_build-next.sh
+++ b/scripts/release/_build-next.sh
@@ -96,7 +96,7 @@ cat <<- EEOOFF
 
     If a custom Git tag has been created to publish a release, the Git tag will be deleted first. Then, the appropriate
     scripts will be called to bump version numbers and publish the repo. Finally, a custom tag will be created to kick
-    off the release for the Angular Patternfly repo.
+    off the release for the Angular PatternFly repo.
 
     Note: Intended for use with Travis only.
 
@@ -109,7 +109,7 @@ cat <<- EEOOFF
     OPTIONS:
     h       Display this message (default)
     a       Angular PatternFly
-    e       Patternfly Eng Release
+    e       PatternFly Eng Release
     p       PatternFly
     r       PatternFly RCUE
 

--- a/scripts/release/_build.sh
+++ b/scripts/release/_build.sh
@@ -96,7 +96,7 @@ cat <<- EEOOFF
 
     If a custom Git tag has been created to publish a release, the Git tag will be deleted first. Then, the appropriate
     scripts will be called to bump version numbers and publish the repo. Finally, a custom tag will be created to kick
-    off the release for the Angular Patternfly, Patternfly Org and RCUE repos.
+    off the release for the Angular PatternFly, PatternFly Org and RCUE repos.
 
     Note: Intended for use with Travis only.
 
@@ -109,11 +109,11 @@ cat <<- EEOOFF
     OPTIONS:
     h       Display this message (default)
     a       Angular PatternFly
-    e       Patternfly Eng Release
+    e       PatternFly Eng Release
     o       PatternFly Org
     p       PatternFly
     r       PatternFly RCUE
-    w       Patternfly Web Components
+    w       PatternFly Web Components
 
 EEOOFF
 }

--- a/scripts/release/_common.sh
+++ b/scripts/release/_common.sh
@@ -7,17 +7,17 @@ git_setup()
   echo "*** Setting up Git env"
   cd $BUILD_DIR
 
-  # Add Angular Patternfly as a remote
+  # Add Angular PatternFly as a remote
   git remote rm $REPO_NAME_PTNFLY_ANGULAR
   git remote add $REPO_NAME_PTNFLY_ANGULAR https://$AUTH_TOKEN@github.com/$REPO_SLUG_PTNFLY_ANGULAR.git
   check $? "git add remote failure"
 
-  # Add Patternfly as a remote
+  # Add PatternFly as a remote
   git remote rm $REPO_NAME_PTNFLY
   git remote add $REPO_NAME_PTNFLY https://$AUTH_TOKEN@github.com/$REPO_SLUG_PTNFLY.git
   check $? "git add remote failure"
 
-  # Add Patternfly Org as a remote
+  # Add PatternFly Org as a remote
   git remote rm $REPO_NAME_PTNFLY_ORG
   git remote add $REPO_NAME_PTNFLY_ORG https://$AUTH_TOKEN@github.com/$REPO_SLUG_PTNFLY_ORG.git
   check $? "git add remote failure"

--- a/scripts/release/notify.sh
+++ b/scripts/release/notify.sh
@@ -40,7 +40,7 @@ Thanks to everyone who participated in this release (both directly and indirectl
 - the PatternFly team
 EEOOFF
 
-  SUBJECT="The Patternfly $VERSION release is now available"
+  SUBJECT="The PatternFly $VERSION release is now available"
   if [ -n "$DRY_RUN" ]; then
     cat $TMP_DIR/$TMP_FILE
   else
@@ -68,7 +68,7 @@ fetch_notes()
 usage()
 {
 cat <<- EEOOFF
-    This script will send a release notice to the Patternfly and Angular Patternfly mailling lists.
+    This script will send a release notice to the PatternFly and Angular PatternFly mailling lists.
 
     After publishing a release notes via GitHub, the script will pull the markup using GitHub APIs. The markup is then
     added to the body of the outgoing message.
@@ -105,11 +105,11 @@ EEOOFF
     case $c in
       h) usage; exit 0;;
       a) EMAIL="$EMAIL_PTNFLY_ANGULAR";
-         SUBJECT="Angular Patternfly";
+         SUBJECT="Angular PatternFly";
          REPO_SLUG=$REPO_SLUG_PTNFLY_ANGULAR;;
       d) DRY_RUN=1;;
       p) EMAIL="$EMAIL_PTNFLY";
-         SUBJECT="Patternfly";
+         SUBJECT="PatternFly";
          REPO_SLUG=$REPO_SLUG_PTNFLY;;
       v) VERSION=$OPTARG;;
       \?) usage; exit 1;;

--- a/scripts/release/publish-npm.sh
+++ b/scripts/release/publish-npm.sh
@@ -55,10 +55,10 @@ cat <<- EEOOFF
     OPTIONS:
     h       Display this message (default)
     a       Angular PatternFly
-    e       Patternfly Eng Release
+    e       PatternFly Eng Release
     p       PatternFly
     r       PatternFly RCUE
-    w       Patternfly Web Components
+    w       PatternFly Web Components
 
     SPECIAL OPTIONS:
     b       The branch to publish (e.g., $NEXT_BRANCH)

--- a/scripts/release/release-all.sh
+++ b/scripts/release/release-all.sh
@@ -43,7 +43,7 @@ cat <<- EEOOFF
     When the release is complete, the custom Git tag is removed from GitHub. The custom tag is created using a clone so
     it won't persist in your local repo.
 
-    If the release is successful, RCUE, Angular Patternfly, and Patternfly Org will be released as well. This is done
+    If the release is successful, RCUE, Angular PatternFly, and PatternFly Org will be released as well. This is done
     by creating a Git tag for the next repo to be built.
 
     If 3.15.0 is provided as a version number; for example, the release will be tagged as v3.15.0.
@@ -59,12 +59,12 @@ cat <<- EEOOFF
     OPTIONS:
     h       Display this message (default)
     a       Angular PatternFly
-    e       Patternfly Eng Release
+    e       PatternFly Eng Release
     o       PatternFly Org
     p       PatternFly
     r       PatternFly RCUE
     v       The version number (e.g., 3.15.0)
-    w       Patternfly Web Components
+    w       PatternFly Web Components
 
     SPECIAL OPTIONS:
     f       Run against repo fork matching local username (e.g., `whoami`/patternfly)

--- a/scripts/release/release.sh
+++ b/scripts/release/release.sh
@@ -221,12 +221,12 @@ cat <<- EEOOFF
     OPTIONS:
     h       Display this message (default)
     a       Angular PatternFly
-    e       Patternfly Eng Release
+    e       PatternFly Eng Release
     o       PatternFly Org
     p       PatternFly
     r       PatternFly RCUE
     v       The version number (e.g., 3.15.0)
-    w       Patternfly Web Components
+    w       PatternFly Web Components
 
     SPECIAL OPTIONS:
     b       The branch to release (e.g., $NEXT_BRANCH)


### PR DESCRIPTION
This change was initiated to correct the PatternFly camel-case in the release notification, but I did a global search and replace to change it throughout.  A review of the changes doesn't indicate any breakages are introduced, but I _haven't_ run the scripts myself to verify.