### PR TITLE
Provided an alternate means of logging into npm when no tty is present

### DIFF
--- a/scripts/release/publish-npm.sh
+++ b/scripts/release/publish-npm.sh
@@ -29,7 +29,11 @@ publish_npm()
 
   # Log into npm
   if [ -n "$NPM_USER" -a -n "$NPM_PWD" ]; then
-    printf "$NPM_USER\n$NPM_PWD\n$NPM_USER@redhat.com" | npm login
+    npm adduser <<!
+$NPM_USER
+$NPM_PWD
+$NPM_USER@redhat.com
+!
     check $? "npm login failure"
   fi
 


### PR DESCRIPTION
This PR should resolve the npm login error seen here:
https://travis-ci.org/patternfly/patternfly/builds/257392565
```
printf [secure]\n[secure]\n[secure]@redhat.com
npm login
Username: Password: npm ERR! cb() never called!
```

This error comes about when `npm login` is executed without a tty present.  See:
https://github.com/npm/npm/issues/11320

This solution was pulled from this stackoverflow answer:
https://stackoverflow.com/a/24154126/264797