### PR TITLE
Reverted the `bash` invocation to use the `bourne shell` interpreter

### DIFF
--- a/scripts/_build.sh
+++ b/scripts/_build.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/sh
 
 default()
 {
@@ -92,10 +92,10 @@ EEOOFF
 
   # Release must remove shrinkwrap prior to install; thus, the Travis install is turned off
   if [ -n "$RELEASE" ]; then
-    $SCRIPT_DIR/release/_build.sh -$SWITCH
+    sh -x $SCRIPT_DIR/release/_build.sh -$SWITCH
     check $? "Release failure"
   elif [ -n "$RELEASE_NEXT" ]; then
-    $SCRIPT_DIR/release/_build-next.sh -$SWITCH
+    sh -x $SCRIPT_DIR/release/_build-next.sh -$SWITCH
     check $? "Release failure"
   else
     build_install
@@ -105,7 +105,7 @@ EEOOFF
     # Skip publish for pull requests and tags
     if [ "$TRAVIS_PULL_REQUEST" = "false" -a -z "$TRAVIS_TAG" ]; then
       if [ -n "$PTNFLY" -o -n "$PTNFLY_ANGULAR" -o -n "$PTNFLY_NG" -o -n "$PTNFLY_WC" ]; then
-        $SCRIPT_DIR/_publish-branch.sh
+        sh -x $SCRIPT_DIR/_publish-branch.sh
         check $? "Publish failure"
       fi
     fi

--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/sh
 
 # Build repo
 #

--- a/scripts/_env.sh
+++ b/scripts/_env.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/sh
 
 # Build PatternFly templates using Jekyll
 export PF_PAGE_BUILDER=jekyll

--- a/scripts/_publish-branch.sh
+++ b/scripts/_publish-branch.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/sh
 
 default()
 {

--- a/scripts/release/_build-next.sh
+++ b/scripts/release/_build-next.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/sh
 
 default()
 {
@@ -157,23 +157,23 @@ EEOOFF
   git_setup
 
   # Bump version numbers, build, and test
-  $SCRIPT_DIR/release.sh -s -n -v $VERSION -$SWITCH
+  sh -x $SCRIPT_DIR/release.sh -s -n -v $VERSION -$SWITCH
   check $? "bump version failure"
 
   # Push version bump and generated files to master and dist branches
   if [ -n "$PTNFLY" -o -n "$PTNFLY_ANGULAR" ]; then
-    $SCRIPT_DIR/_publish-branch.sh -m -b $NEXT_BRANCH
-    $SCRIPT_DIR/_publish-branch.sh -d -b $NEXT_DIST_BRANCH
+    sh -x $SCRIPT_DIR/_publish-branch.sh -m -b $NEXT_BRANCH
+    sh -x $SCRIPT_DIR/_publish-branch.sh -d -b $NEXT_DIST_BRANCH
   elif [ -n "$RCUE" ]; then
-    $SCRIPT_DIR/_publish-branch.sh -m -b $NEXT_BRANCH
+    sh -x $SCRIPT_DIR/_publish-branch.sh -m -b $NEXT_BRANCH
   else
-    $SCRIPT_DIR/_publish-branch.sh -m
+    sh -x $SCRIPT_DIR/_publish-branch.sh -m
   fi
   check $? "Publish failure"
 
   # NPM publish
   if [ -z "$SKIP_NPM_PUBLISH" ]; then
-    $SCRIPT_DIR/publish-npm.sh -n -s -$SWITCH
+    sh -x $SCRIPT_DIR/publish-npm.sh -n -s -$SWITCH
     check $? "npm publish failure"
   fi
 

--- a/scripts/release/_build.sh
+++ b/scripts/release/_build.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/sh
 
 default()
 {
@@ -169,27 +169,27 @@ EEOOFF
   git_setup
 
   # Bump version numbers, build, and test
-  $SCRIPT_DIR/release.sh -s -v $VERSION -$SWITCH
+  sh -x $SCRIPT_DIR/release.sh -s -v $VERSION -$SWITCH
   check $? "bump version failure"
 
   # Push version bump and generated files to master and dist branches
   if [ -n "$PTNFLY" -o -n "$PTNFLY_ANGULAR" -o -n "$PTNFLY_NG" -o -n "$PTNFLY_WC" ]; then
-    $SCRIPT_DIR/_publish-branch.sh -m -d
+    sh -x $SCRIPT_DIR/_publish-branch.sh -m -d
   else
-    $SCRIPT_DIR/_publish-branch.sh -m
+    sh -x $SCRIPT_DIR/_publish-branch.sh -m
   fi
   check $? "Publish failure"
 
   # NPM publish
   if [ -z "$SKIP_NPM_PUBLISH" -a -z "$PTNFLY_ORG" ]; then
-    $SCRIPT_DIR/publish-npm.sh -s -$SWITCH
+    sh -x $SCRIPT_DIR/publish-npm.sh -s -$SWITCH
     check $? "npm publish failure"
   fi
 
   # Webjar publish
   if [ -z "$SKIP_WEBJAR_PUBLISH" ]; then
     if [ -n "$PTNFLY" -o -n "$PTNFLY_ANGULAR" ]; then
-      $SCRIPT_DIR/publish-webjar.sh -v $VERSION -$SWITCH
+      sh -x $SCRIPT_DIR/publish-webjar.sh -v $VERSION -$SWITCH
       check $? "webjar publish failure"
     fi
   fi

--- a/scripts/release/_common.sh
+++ b/scripts/release/_common.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/sh
 
 # Setup env for use with GitHub
 #

--- a/scripts/release/_publish-branch.sh
+++ b/scripts/release/_publish-branch.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/sh
 
 #
 # Note: When run against a tag, TRAVIS_BRANCH won't equal the branch name "master", but whatever was given as

--- a/scripts/release/notify-next.sh
+++ b/scripts/release/notify-next.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/sh
 
 default()
 {

--- a/scripts/release/notify.sh
+++ b/scripts/release/notify.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/sh
 
 default()
 {

--- a/scripts/release/publish-npm.sh
+++ b/scripts/release/publish-npm.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/sh
 
 default()
 {
@@ -27,8 +27,14 @@ publish_npm()
   echo "*** Publishing npm"
   cd $BUILD_DIR
 
+  NPM_FILE=".npmrc"
+  if [ -n "$NPM_TOKEN" -a ! -f "$NPM_FILE" ]; then
+    echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" > $NPM_FILE
+  fi
+
   # Log into npm if not already logged in
-  if [[ $(npm whoami 2> /dev/null) != 'patternfly-build' && -n "$NPM_USER" && -n "$NPM_PWD" ]]; then
+  WHOAMI=`npm whoami`
+  if [ "$WHOAMI" != "patternfly-build" -a -n "$NPM_USER" -a -n "$NPM_PWD" ]; then
     printf "$NPM_USER\n$NPM_PWD\n$NPM_USER@redhat.com" | npm login
     check $? "npm login failure"
   fi

--- a/scripts/release/publish-webjar.sh
+++ b/scripts/release/publish-webjar.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/sh
 
 default()
 {

--- a/scripts/release/release-all.sh
+++ b/scripts/release/release-all.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/sh
 
 default()
 {

--- a/scripts/release/release-all.sh
+++ b/scripts/release/release-all.sh
@@ -76,17 +76,6 @@ EEOOFF
 
 # main()
 {
-  # Source env.sh afer setting REPO_FORK
-  if [ -z "$TRAVIS" ]; then
-    while getopts haefnoprsv:wx c; do
-      case $c in
-        f) REPO_FORK=1;;
-        \?) ;;
-      esac
-    done
-    unset OPTIND
-  fi
-
   default
 
   if [ "$#" -eq 0 ]; then
@@ -97,34 +86,54 @@ EEOOFF
   while getopts haefnoprsv:wx c; do
     case $c in
       h) usage; exit 0;;
-      a) PTNFLY_ANGULAR=1;
-         BUILD_DIR=$TMP_DIR/angular-patternfly;
-         REPO_SLUG=$REPO_SLUG_PTNFLY_ANGULAR;;
-      e) PTNFLY_ENG_RELEASE=1;
-         BUILD_DIR=$TMP_DIR/patternfly-eng-release;
-         REPO_SLUG=$REPO_SLUG_PTNFLY_ENG_RELEASE;;
-      f) ;;
+      a) PTNFLY_ANGULAR=1;;
+      e) PTNFLY_ENG_RELEASE=1;;
+      f) REPO_FORK=1;;
       n) RELEASE_NEXT=1;;
-      o) PTNFLY_ORG=1;
-         BUILD_DIR=$TMP_DIR/patternfly-org;
-         REPO_SLUG=$REPO_SLUG_PTNFLY_ORG;;
-      p) PTNFLY=1;
-         BUILD_DIR=$TMP_DIR/patternfly;
-         REPO_SLUG=$REPO_SLUG_PTNFLY;;
-      r) RCUE=1;
-         BUILD_DIR=$TMP_DIR/rcue;
-         REPO_SLUG=$REPO_SLUG_RCUE;;
+      o) PTNFLY_ORG=1;;
+      p) PTNFLY=1;;
+      r) RCUE=1;;
       s) SKIP_CHAINED_RELEASE=1;;
       v) VERSION=$OPTARG;;
-      w) PTNFLY_WC=1;
-         BUILD_DIR=$TMP_DIR/patternfly-webcomponents;
-         REPO_SLUG=$REPO_SLUG_PTNFLY_WC;;
-      x) PTNFLY_NG=1;
-         BUILD_DIR=$TMP_DIR/patternfly-ng;
-         REPO_SLUG=$REPO_SLUG_PTNFLY_NG;;
+      w) PTNFLY_WC=1;;
+      x) PTNFLY_NG=1;;
       \?) usage; exit 1;;
     esac
   done
+
+  # Source env.sh afer setting REPO_FORK
+  if [ -n "$REPO_FORK" ]; then
+    default
+  fi
+
+  if [ -n "PTNFLY_ANGULAR" ]; then
+    BUILD_DIR=$TMP_DIR/angular-patternfly
+    REPO_SLUG=$REPO_SLUG_PTNFLY_ANGULAR
+  fi
+  if [ -n "PTNFLY_ENG_RELEASE" ]; then
+    BUILD_DIR=$TMP_DIR/patternfly-eng-release
+    REPO_SLUG=$REPO_SLUG_PTNFLY_ENG_RELEASE
+  fi
+  if [ -n "PTNFLY_ORG" ]; then
+    BUILD_DIR=$TMP_DIR/patternfly-org
+    REPO_SLUG=$REPO_SLUG_PTNFLY_ORG
+  fi
+  if [ -n "PTNFLY" ]; then
+    BUILD_DIR=$TMP_DIR/patternfly
+    REPO_SLUG=$REPO_SLUG_PTNFLY
+  fi
+  if [ -n "RCUE" ]; then
+    BUILD_DIR=$TMP_DIR/rcue
+    REPO_SLUG=$REPO_SLUG_RCUE
+  fi
+  if [ -n "PTNFLY_WC" ]; then
+    BUILD_DIR=$TMP_DIR/patternfly-webcomponents
+    REPO_SLUG=$REPO_SLUG_PTNFLY_WC
+  fi
+  if [ -n "PTNFLY_NG" ]; then
+    BUILD_DIR=$TMP_DIR/patternfly-ng
+    REPO_SLUG=$REPO_SLUG_PTNFLY_NG
+  fi
 
   if [ -z "$VERSION" -o -z "$REPO_SLUG" ]; then
     usage

--- a/scripts/release/release.sh
+++ b/scripts/release/release.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/sh
 
 default()
 {


### PR DESCRIPTION
Reverted the `bash` invocation to use the `bourne shell` interpreter. The `bash` interpreter can run these scripts, but they were intended to be written in `bourne shell`. Once we start mixing syntax, the scripts can only run using the bash interpreter.

That said, I removed the use of OPTIND for compatibility with Linux. Using OPTIND appears to break when run on Linux, which is why the `bash` interpreter was added as a workaround. Removing OPTIND should allow the scripts to run as originally intended.