### PR TITLE
Generate shrink-wrap for Patternfly only

### DIFF
--- a/scripts/_build.sh
+++ b/scripts/_build.sh
@@ -105,7 +105,7 @@ EEOOFF
 
     # Skip for pull requests and tags
     if [ "$TRAVIS_PULL_REQUEST" = "false" -a -z "$TRAVIS_TAG" ]; then
-      if [ -n "$PTNFLY" -o -n "$PTNFLY_ANGULAR" -o -n "$PTNFLY_NG" -o -n "$PTNFLY_WC" ]; then
+      if [ -n "$PTNFLY" ]; then
         sh -x $SCRIPT_DIR/_shrinkwrap.sh
         check $? "Shrinkwrap failure"
       fi


### PR DESCRIPTION
Generating a shrinkwrap file appears to be causing issues building (testing with karma) the master-dist branch for Angular Patternfly. Will revisit introducing shirnkwrap after the new symantic release process is stable.