### PR TITLE
Disable release.sh and release-all.sh features

### DIFF
--- a/scripts/release/release-all.sh
+++ b/scripts/release/release-all.sh
@@ -57,14 +57,14 @@ cat <<- EEOOFF
 
     OPTIONS:
     h       Display this message (default)
-    a       Angular PatternFly
-    e       PatternFly Eng Release
+    a       Angular PatternFly (DISABLED for semantic release)
+    e       PatternFly Eng Release (DISABLED for semantic release)
     o       PatternFly Org
-    p       PatternFly
+    p       PatternFly (DISABLED for semantic release)
     r       RCUE
     v       The version number (e.g., 3.15.0)
-    w       PatternFly Web Components
-    x       Patternfly NG
+    w       PatternFly Web Components (DISABLED for semantic release)
+    x       Patternfly NG (DISABLED for semantic release)
 
     SPECIAL OPTIONS:
     s       Skip chained releases.
@@ -86,17 +86,17 @@ EEOOFF
   while getopts haefnoprsv:wx c; do
     case $c in
       h) usage; exit 0;;
-      a) PTNFLY_ANGULAR=1;;
-      e) PTNFLY_ENG_RELEASE=1;;
+      a) PTNFLY_ANGULAR=1; usage; exit1;; # DISABLED
+      e) PTNFLY_ENG_RELEASE=1; usage; exit1;; # DISABLED
       f) REPO_FORK=1;;
       n) RELEASE_NEXT=1;;
       o) PTNFLY_ORG=1;;
-      p) PTNFLY=1;;
+      p) PTNFLY=1; usage; exit1;; # DISABLED
       r) RCUE=1;;
       s) SKIP_CHAINED_RELEASE=1;;
       v) VERSION=$OPTARG;;
-      w) PTNFLY_WC=1;;
-      x) PTNFLY_NG=1;;
+      w) PTNFLY_WC=1; usage; exit1;; # DISABLED
+      x) PTNFLY_NG=1; usage; exit1;; # DISABLED
       \?) usage; exit 1;;
     esac
   done

--- a/scripts/release/release.sh
+++ b/scripts/release/release.sh
@@ -44,17 +44,21 @@ bump_bower()
   if [ -n "$PTNFLY" ]; then
     sed "s|\"version\":.*|\"version\": \"$VERSION\",|" $BOWER_JSON > $BOWER_JSON.tmp
   elif [ -n "$PTNFLY_ANGULAR" ]; then
-    # Removed Patternfy bump from a-pf release
     #sed "s|\"patternfly\":.*|\"patternfly\": \"$PKG_PTNFLY\"|" $BOWER_JSON > $BOWER_JSON.tmp
 
     sed "s|\"version\":.*|\"version\": \"$VERSION\",|" $BOWER_JSON > $BOWER_JSON.tmp
   elif [ -n "$PTNFLY_NG" ]; then
-    sed "s|\"version\":.*|\"version\": \"$VERSION\",|" $BOWER_JSON | \
-    sed "s|\"patternfly\":.*|\"patternfly\": \"$PKG_PTNFLY\"|" > $BOWER_JSON.tmp
+    #sed "s|\"version\":.*|\"version\": \"$VERSION\",|" $BOWER_JSON | \
+    #sed "s|\"patternfly\":.*|\"patternfly\": \"$PKG_PTNFLY\"|" > $BOWER_JSON.tmp
+
+    sed "s|\"version\":.*|\"version\": \"$VERSION\",|" $BOWER_JSON > $BOWER_JSON.tmp
   elif [ -n "$PTNFLY_ORG" ]; then
+    #sed "s|\"version\":.*|\"version\": \"$VERSION\",|" $BOWER_JSON | \
+    #sed "s|\"patternfly\":.*|\"patternfly\": \"$PKG_PTNFLY\",|" | \
+    #sed "s|\"angular-patternfly\":.*|\"angular-patternfly\": \"$PKG_PTNFLY_ANGULAR\",|" > $BOWER_JSON.tmp
+
     sed "s|\"version\":.*|\"version\": \"$VERSION\",|" $BOWER_JSON | \
-    sed "s|\"patternfly\":.*|\"patternfly\": \"$PKG_PTNFLY\",|" | \
-    sed "s|\"angular-patternfly\":.*|\"angular-patternfly\": \"$PKG_PTNFLY_ANGULAR\",|" > $BOWER_JSON.tmp
+    sed "s|\"patternfly\":.*|\"patternfly\": \"$PKG_PTNFLY\",|" > $BOWER_JSON.tmp
   elif [ -n "$RCUE" ]; then
     sed "s|\"version\":.*|\"version\": \"$VERSION\",|" $BOWER_JSON | \
     sed "s|\"patternfly\":.*|\"patternfly\": \"$PKG_PTNFLY\"|" > $BOWER_JSON.tmp
@@ -84,25 +88,35 @@ bump_package()
   fi
 
   if [ -n "$PTNFLY" ]; then
-    sed "s|\"version\":.*|\"version\": \"$VERSION\",|" $PACKAGE_JSON | \
-    sed "s|\"patternfly-eng-release\":.*|\"patternfly-eng-release\": \"$PKG_PTNFLY_ENG_RELEASE\",|" > $PACKAGE_JSON.tmp
+    #sed "s|\"version\":.*|\"version\": \"$VERSION\",|" $PACKAGE_JSON | \
+    #sed "s|\"patternfly-eng-release\":.*|\"patternfly-eng-release\": \"$PKG_PTNFLY_ENG_RELEASE\",|" > $PACKAGE_JSON.tmp
+
+    sed "s|\"version\":.*|\"version\": \"$VERSION\",|" $PACKAGE_JSON > $PACKAGE_JSON.tmp
   elif [ -n "$PTNFLY_ANGULAR" ]; then
-    # Removed Patternfy bump from a-pf release
+    #sed "s|\"version\":.*|\"version\": \"$VERSION\",|" $PACKAGE_JSON | \
     #sed "s|\"patternfly\":.*|\"patternfly\": \"$PKG_PTNFLY\"|" | \
+    #sed "s|\"patternfly-eng-release\":.*|\"patternfly-eng-release\": \"$PKG_PTNFLY_ENG_RELEASE\",|" > $PACKAGE_JSON.tmp
+
+    sed "s|\"version\":.*|\"version\": \"$VERSION\",|" $PACKAGE_JSON > $PACKAGE_JSON.tmp
+  elif [ -n "$PTNFLY_NG" ]; then
+    #sed "s|\"version\":.*|\"version\": \"$VERSION\",|" $PACKAGE_JSON | \
+    #sed "s|\"patternfly\":.*|\"patternfly\": \"$PKG_PTNFLY\"|" | \
+    #sed "s|\"patternfly-eng-release\":.*|\"patternfly-eng-release\": \"$PKG_PTNFLY_ENG_RELEASE\",|" > $PACKAGE_JSON.tmp
+
+    sed "s|\"version\":.*|\"version\": \"$VERSION\",|" $PACKAGE_JSON > $PACKAGE_JSON.tmp
+  elif [ -n "$PTNFLY_ORG" ]; then
+    #sed "s|\"version\":.*|\"version\": \"$VERSION\",|" $PACKAGE_JSON | \
+    #sed "s|\"patternfly-eng-release\":.*|\"patternfly-eng-release\": \"$PKG_PTNFLY_ENG_RELEASE\",|" > $PACKAGE_JSON.tmp
 
     sed "s|\"version\":.*|\"version\": \"$VERSION\",|" $PACKAGE_JSON | \
-    sed "s|\"patternfly-eng-release\":.*|\"patternfly-eng-release\": \"$PKG_PTNFLY_ENG_RELEASE\",|" > $PACKAGE_JSON.tmp
-  elif [ -n "$PTNFLY_NG" ]; then
-    sed "s|\"version\":.*|\"version\": \"$VERSION\",|" $PACKAGE_JSON | \
-    sed "s|\"patternfly\":.*|\"patternfly\": \"$PKG_PTNFLY\"|" | \
-    sed "s|\"patternfly-eng-release\":.*|\"patternfly-eng-release\": \"$PKG_PTNFLY_ENG_RELEASE\",|" > $PACKAGE_JSON.tmp
-  elif [ -n "$PTNFLY_ORG" ]; then
-    sed "s|\"version\":.*|\"version\": \"$VERSION\",|" $PACKAGE_JSON | \
-    sed "s|\"patternfly-eng-release\":.*|\"patternfly-eng-release\": \"$PKG_PTNFLY_ENG_RELEASE\",|" > $PACKAGE_JSON.tmp
+    sed "s|\"patternfly\":.*|\"patternfly\": \"$PKG_PTNFLY\",|" > $PACKAGE_JSON.tmp
   elif [ -n "$RCUE" ]; then
+    #sed "s|\"version\":.*|\"version\": \"$VERSION\",|" $PACKAGE_JSON | \
+    #sed "s|\"patternfly\":.*|\"patternfly\": \"$PKG_PTNFLY\"|" | \
+    #sed "s|\"patternfly-eng-release\":.*|\"patternfly-eng-release\": \"$PKG_PTNFLY_ENG_RELEASE\"|" > $PACKAGE_JSON.tmp
+
     sed "s|\"version\":.*|\"version\": \"$VERSION\",|" $PACKAGE_JSON | \
-    sed "s|\"patternfly\":.*|\"patternfly\": \"$PKG_PTNFLY\"|" | \
-    sed "s|\"patternfly-eng-release\":.*|\"patternfly-eng-release\": \"$PKG_PTNFLY_ENG_RELEASE\"|" > $PACKAGE_JSON.tmp
+    sed "s|\"patternfly\":.*|\"patternfly\": \"$PKG_PTNFLY\"|" > $PACKAGE_JSON.tmp
   elif [ -n "$PTNFLY_ENG_RELEASE" ]; then
     sed "s|\"version\":.*|\"version\": \"$VERSION\",|" $PACKAGE_JSON > $PACKAGE_JSON.tmp
   elif [ -n "$PTNFLY_WC" ]; then
@@ -232,14 +246,14 @@ cat <<- EEOOFF
 
     OPTIONS:
     h       Display this message (default)
-    a       Angular PatternFly
-    e       PatternFly Eng Release
+    a       Angular PatternFly (DISABLED for semantic release)
+    e       PatternFly Eng Release (DISABLED for semantic release)
     o       PatternFly Org
-    p       PatternFly
+    p       PatternFly (DISABLED for semantic release)
     r       RCUE
     v       The version number (e.g., 3.15.0)
-    w       PatternFly Web Components
-    x       Patternfly NG
+    w       PatternFly Web Components (DISABLED for semantic release)
+    x       Patternfly NG (DISABLED for semantic release)
 
     SPECIAL OPTIONS:
     b       The branch to release (e.g., $NEXT_BRANCH)
@@ -290,20 +304,20 @@ verify()
   while getopts hab:efgnoprsv:wx c; do
     case $c in
       h) usage; exit 0;;
-      a) PTNFLY_ANGULAR=1;;
+      a) PTNFLY_ANGULAR=1; usage; exit 1;; # DISABLED
       b) BRANCH=$OPTARG;;
-      e) PTNFLY_ENG_RELEASE=1;;
+      e) PTNFLY_ENG_RELEASE=1; usage; exit 1;; # DISABLED
       f) REPO_FORK=1;;
       g) PUSH=1;;
       n) BRANCH_DIST=$NEXT_DIST_BRANCH;;
       o) PTNFLY_ORG=1;;
-      p) PTNFLY=1;;
+      p) PTNFLY=1; usage; exit 1;; # DISABLED
       r) RCUE=1;;
       s) SKIP_SETUP=1;;
       v) VERSION=$OPTARG;
          BUMP_BRANCH=bump-v$VERSION;;
-      w) PTNFLY_WC=1;;
-      x) PTNFLY_NG=1;;
+      w) PTNFLY_WC=1; usage; exit 1;; # DISABLED
+      x) PTNFLY_NG=1; usage; exit 1;; # DISABLED
       \?) usage; exit 1;;
     esac
   done

--- a/scripts/semantic-release/_release.sh
+++ b/scripts/semantic-release/_release.sh
@@ -33,22 +33,10 @@ bump_bower()
     return
   fi
 
-  # For testing forks without npm publish, set REPO_FORK=1 via local env
-  if [ -n "$REPO_FORK" ]; then
-    PKG_PTNFLY="git://$REPO_URL_PTNFLY#$BRANCH_DIST"
-    PKG_PTNFLY_ANGULAR="git://$REPO_URL_PTNFLY_ANGULAR#$BRANCH_DIST"
-  else
-    PKG_PTNFLY=`npm show patternfly version`
-    PKG_PTNFLY_ANGULAR=`npm show angular-patternfly version`
-  fi
-
   if [ -n "$PTNFLY" ]; then
     sed "s|\"version\":.*|\"version\": \"$VERSION\",|" $BOWER_JSON > $BOWER_JSON.tmp
   elif [ -n "$PTNFLY_ANGULAR" ]; then
     sed "s|\"version\":.*|\"version\": \"$VERSION\",|" $BOWER_JSON > $BOWER_JSON.tmp
-  elif [ -n "$PTNFLY_NG" ]; then
-    sed "s|\"version\":.*|\"version\": \"$VERSION\",|" $BOWER_JSON | \
-    sed "s|\"patternfly\":.*|\"patternfly\": \"$PKG_PTNFLY\"|" > $BOWER_JSON.tmp
   fi
   check $? "Version bump failure"
 


### PR DESCRIPTION
Disabled repo support for release.sh and release-all.sh in favor of semantic release. We don't want anyone accidentally overriding the semantic release process.

The patternfly-org and RCUE repos are still supported.