### PR TITLE
fix merge_prereqs() return value

### DIFF
--- a/scripts/semantic-release/_common.sh
+++ b/scripts/semantic-release/_common.sh
@@ -10,6 +10,6 @@ merge_prereqs()
   # Skip for pull requests and tags
   if [ "$TRAVIS_PULL_REQUEST" != "false" -o -n "$TRAVIS_TAG" ]; then
     echo "*** This build is running against a pull request or tag! Exiting..."
-    exit 1
+    exit 0
   fi
 }


### PR DESCRIPTION
Cannot use ‘exit 1’ in merge_prereqs() or Travis build fails. Must use 'exit 0' instead.