### PR TITLE
Copy contents of dist to root directory for npm publish

### DIFF
--- a/scripts/_env.sh
+++ b/scripts/_env.sh
@@ -110,7 +110,6 @@ BOWER_JSON=bower.json
 DIST_DEMO_DIR=dist-demo
 DIST_DIR=dist
 GEM_FILE=Gemfile
-GIT_DIR=.git
 GRUNT_FILE_JS=Gruntfile.js
 GRUNT_NGDOCS_TMPL=grunt-ngdocs-index.tmpl
 GULP_FILE_JS=gulpfile.js


### PR DESCRIPTION
Currently, patternfly-ng publishes from the dist directory. In order to properly support semantic-release, 'npm publish' must be run from the root only. When publishing a sub-folder, npm loses the ability to insert the correct gitHead information, which prevents semantic-release from working properly.

This solution copies the contents of the dist directory to the root directory. The .npmignore file lists
anything in the root that should not be published.