### PR TITLE
Force push to forked repos

### DIFF
--- a/scripts/_build.sh
+++ b/scripts/_build.sh
@@ -19,7 +19,14 @@ prereqs()
   echo "*** This build is running against $TRAVIS_REPO_SLUG"
   cd $BUILD_DIR
 
-  if [ -n "$TRAVIS_TAG" ]; then
+  # Ensure semantic release runs for applicable repos
+  case $SWITCH in
+    a|e|p|w|x) SYMANTIC_RELEASE=1;;
+  esac
+
+  if [ -n "$SYMANTIC_RELEASE" ]; then
+    echo "*** This build is running a semantic release"
+  elif [ -n "$TRAVIS_TAG" ]; then
     echo "*** This build is running against $TRAVIS_TAG"
 
     # Get version from tag
@@ -73,23 +80,18 @@ EEOOFF
     case $c in
       h) usage; exit 0;;
       a) PTNFLY_ANGULAR=1;
-         SYMANTIC_RELEASE=1;
          SWITCH=a;;
       e) PTNFLY_ENG_RELEASE=1;
-         SYMANTIC_RELEASE=1;
          SWITCH=e;;
       o) PTNFLY_ORG=1;
          SWITCH=o;;
       p) PTNFLY=1;
-         SYMANTIC_RELEASE=1;
          SWITCH=p;;
       r) RCUE=1;
          SWITCH=r;;
       w) PTNFLY_WC=1;
-         SYMANTIC_RELEASE=1;
          SWITCH=w;;
       x) PTNFLY_NG=1;
-         SYMANTIC_RELEASE=1;
          SWITCH=x;;
       \?) usage; exit 1;;
     esac
@@ -107,6 +109,7 @@ EEOOFF
     check $? "Release failure"
   elif [ -n "$SYMANTIC_RELEASE" ]; then
     sh -x $SCRIPT_DIR/semantic-release/_release.sh -$SWITCH
+    check $? "Semantic release failure"
   else
     build_install
     build

--- a/scripts/semantic-release/_publish-branch.sh
+++ b/scripts/semantic-release/_publish-branch.sh
@@ -50,7 +50,8 @@ push_dist()
   # Push to dist branch
   EXISTING=`git ls-remote --heads https://github.com/$TRAVIS_REPO_SLUG.git $BRANCH_DIST`
 
-  if [ -n "$EXISTING" ]; then
+  # Skip merge if we're building a forked repo
+  if [ -n "$EXISTING" -a -z "$REPO_FORK" ]; then
     git fetch upstream $BRANCH_DIST:$BRANCH_DIST # <remote-branch>:<local-branch>
     git checkout $BRANCH_DIST
     git merge -X theirs $TRAVIS_BRANCH-local --no-edit --ff
@@ -58,7 +59,7 @@ push_dist()
 
     git push upstream $BRANCH_DIST -v
   else
-    git push upstream $TRAVIS_BRANCH-local:$BRANCH_DIST -v # <local-branch>:<remote-branch>
+    git push upstream $TRAVIS_BRANCH-local:$BRANCH_DIST -f -v # <local-branch>:<remote-branch>
   fi
   check $? "git push failure"
 }
@@ -89,15 +90,15 @@ cat <<- EEOOFF
 
     AUTH_TOKEN must be set via Travis CI.
 
-    sh [-x] $SCRIPT [-h|f] -c|d|o
+    sh [-x] $SCRIPT [-h] -c|d|o
 
     Example: sh $SCRIPT -d
 
     OPTIONS:
     h       Display this message (default)
-    c       Commit all changes
-    d       Force commit dist directory
-    o       Force commit dist-demo directory
+    c       Commit changes
+    d       Commit dist directory
+    o       Commit dist-demo directory
 
 EEOOFF
 }


### PR DESCRIPTION
Force push to -dist branch for forked repos only. This should help avoid potential merge conflicts when fixes are applied to PRs. The alternative to resolving a conflict is to remove the -dist branch and allow it to be recreated.