### PR TITLE
Test npm build first for patternfly-ng

### DIFF
--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -7,8 +7,13 @@ build()
   echo "*** Building `pwd`"
   cd $BUILD_DIR
 
-  # Grunt build
-  if [ -s "$GRUNT_FILE_JS" ]; then
+  # NPM script build
+  JUNK=`npm run | awk -F' ' '{print $1}' | grep '^build$'`
+
+  if [ "$?" -eq 0 ]; then
+    npm run build
+  elif [ -s "$GRUNT_FILE_JS" ]; then
+    # Grunt build
     JUNK=`grep production "$GRUNT_FILE_JS"`
     if [ "$?" -eq 0 ]; then
       PRODUCTION=:production
@@ -20,12 +25,6 @@ build()
     fi
   elif [ -s "$GULP_FILE_JS" ]; then
     gulp build
-  else
-    # NPM script build
-    JUNK=`npm run | awk -F' ' '{print $1}' | grep '^build'`
-    if [ "$?" -eq 0 ]; then
-      npm run build
-    fi
   fi
   check $? "Build failure"
 


### PR DESCRIPTION
Test npm build first for patternfly-ng. This will ensure that the demo is built for rawgit.