### PR TITLE
package.json version not bumped properly

### DIFF
--- a/scripts/release/release.sh
+++ b/scripts/release/release.sh
@@ -109,7 +109,7 @@ bump_package()
     #sed "s|\"patternfly-eng-release\":.*|\"patternfly-eng-release\": \"$PKG_PTNFLY_ENG_RELEASE\",|" > $PACKAGE_JSON.tmp
 
     sed "s|\"version\":.*|\"version\": \"$VERSION\",|" $PACKAGE_JSON | \
-    sed "s|\"patternfly\":.*|\"patternfly\": \"$PKG_PTNFLY\",|" > $PACKAGE_JSON.tmp
+    sed "s|\"patternfly\": \".*|\"patternfly\": \"$PKG_PTNFLY\",|" > $PACKAGE_JSON.tmp
   elif [ -n "$RCUE" ]; then
     #sed "s|\"version\":.*|\"version\": \"$VERSION\",|" $PACKAGE_JSON | \
     #sed "s|\"patternfly\":.*|\"patternfly\": \"$PKG_PTNFLY\"|" | \


### PR DESCRIPTION
For patternfly-org, ‘patternfly’ appears on multiple lines in package.json. The script incorrectly bumps the version in more than one place. 

This change ensures the patternfly package version is bumped properly and the patternfly-org build succeeds.