### PR TITLE
Avoid generating shrinkwrap if package-lock is found

### DIFF
--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -141,7 +141,7 @@ shrinkwrap()
   echo "*** Shrink wrapping $SHRINKWRAP_JSON"
   cd $BUILD_DIR
 
-  if [ -n "$PTNFLY_ENG_RELEASE" ]; then
+  if [ -s "$PACKAGE_LOCK_JSON" -o -n "$PTNFLY_ENG_RELEASE" ]; then
     return
   fi
 

--- a/scripts/_env.sh
+++ b/scripts/_env.sh
@@ -123,6 +123,7 @@ LICENSE=LICENSE.txt
 NPM_IGNORE=.npmignore
 NSP=node_modules/nsp/bin/nsp
 PACKAGE_JSON=package.json
+PACKAGE_LOCK_JSON=package-lock.json
 PTNFLY_SETTINGS_JS=src/js/patternfly-settings-base.js
 README=README.md
 SHRINKWRAP_JSON=npm-shrinkwrap.json


### PR DESCRIPTION
This change avoids generating a shrinkwrap file if package-lock.json is found. It also skips running the shrinkwrap vulnerability test.