### PR TITLE
verify.sh: use 'npm pack' to avoid installing a softlink

### DIFF
--- a/scripts/semantic-release/_verify.sh
+++ b/scripts/semantic-release/_verify.sh
@@ -54,7 +54,8 @@ verify()
   cd $1
 
   if [ -s "$2/$PACKAGE_JSON" ]; then
-    npm install $2
+    # Using pack to avoid installing a softlink
+    npm install `npm pack $2`
     check $? "npm install failure"
 
     if [ ! -d "$1"/node_modules ]; then


### PR DESCRIPTION
I've observed (using npm 5.3.0) that installing patternfly-ng from a built workspace will create a softlink. This prevents the post install script from running. In order to test an npm install properly, and run the post install script, `npm pack` should be run first on the built workspace.