### PR TITLE
fix(rcue): remove references to RCUE build

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # patternfly-eng-release
-A set of release engineering scripts for PatternFly, Angular PatternFly, PatternFly Org, and RCUE
+A set of release engineering scripts for PatternFly, Angular PatternFly, PatternFly Org
 
 ## Builds
 
@@ -13,7 +13,7 @@ Where applicable to each repo, the scripts may clone a new GitHub repo, bump the
 
 The automated release build begins with the build/release/release-all.sh script. This script will push a custom release tag to the repo's master branch, which triggers Travis to run the build/release/build.sh script. Version bump changes are pushed back to the master branch. The version bump and generated build changes are pushed to master-dist and tagged (e.g., v3.15.0).
 
-Release builds are chained together by pushing a new custom release tag to the next repo. For example, if the PatternFly RE release is successful, PatternFly is built next. If the PatternFly release is successful, RCUE and Angular PatternFly are built simultaneously. If Angular is successful, PatternFly Org is released as well.
+Release builds are chained together by pushing a new custom release tag to the next repo. For example, if the PatternFly RE release is successful, PatternFly is built next. If the PatternFly release is successful, Angular PatternFly is built. If Angular is successful, PatternFly Org is released as well.
 
 Should a release build fail at any point, it can be fixed and restarted. For example, If Angular PatternFly fails, it can be restarted and the PatternFly Org release will follow. We don't necessarily need to bump the npm version number again or rebuild Patternfy. The npm publish is one of the last steps in the build.
 
@@ -21,7 +21,7 @@ Of course, we still have the ability to run the release manually using the build
 
 ### build/release/release-all.sh
 
-This script is used to automate and chain releases together. For example, when the PatternFly RE release is complete, PatternFly is built next. When the PatternFly release is complete, the release processes for Angular PatternFly and RCUE are kicked off simultaneously. When the Angular PatternFly release is complete, PatternFly Org shall be released as well.
+This script is used to automate and chain releases together. For example, when the PatternFly RE release is complete, PatternFly is built next. When the PatternFly release is complete, the release processes for Angular PatternFly is kicked off. When the Angular PatternFly release is complete, PatternFly Org shall be released as well.
 
 Although there is no PR to deal with here, creating release notes is still a task which must be performed manually via GitHub.
 
@@ -85,7 +85,6 @@ Alternatively, the following variables may be overridden to test forked repos an
 - REPO_SLUG_PTNFLY_ANGULAR=`owner_name`/angular-patternfly
 - REPO_SLUG_PTNFLY_ORG=`owner_name`/patternfly-org
 - REPO_SLUG_PTNFLY_ENG_RELEASE=`owner_name`/patternfly-eng-release
-- REPO_SLUG_RCUE=`owner_name`/rcue
 - SKIP_NPM_PUBLISH=1
 - SKIP_WEBJAR_PUBLISH=1
 
@@ -129,8 +128,8 @@ This script will bump version numbers, build, shrinkwrap, test, install, push to
 7. Community email sent to announce release
 
 ### build/release/publish-npm.sh
- 
+
 This script will npm publish from the latest repo clone or Travis build.
- 
+
 1. Create an NPM account and become a collaborator for https://www.npmjs.com/package/patternfly
  - Run sh ./build/release/publish-npm.sh -a|e|p

--- a/scripts/_build.sh
+++ b/scripts/_build.sh
@@ -60,7 +60,6 @@ cat <<- EEOOFF
     e       PatternFly Eng Release
     o       PatternFly Org
     p       PatternFly
-    r       RCUE
     w       PatternFly Web Components
     x       Patternfly NG
 
@@ -87,8 +86,6 @@ EEOOFF
          SWITCH=o;;
       p) PTNFLY=1;
          SWITCH=p;;
-      r) RCUE=1;
-         SWITCH=r;;
       w) PTNFLY_WC=1;
          SWITCH=w;;
       x) PTNFLY_NG=1;

--- a/scripts/_env.sh
+++ b/scripts/_env.sh
@@ -9,7 +9,6 @@ export PF_PAGE_BUILDER=jekyll
 # Email used to notify users release is available
 EMAIL_PTNFLY=patternfly@redhat.com
 EMAIL_PTNFLY_ANGULAR=patternfly-angular@redhat.com
-EMAIL_RCUE=patternfly@redhat.com
 
 # Git properties
 GIT_USER_NAME=patternfly-build
@@ -50,19 +49,16 @@ REPO_NAME_PTNFLY_NG=patternfly-ng
 REPO_NAME_PTNFLY_ORG=patternfly-org
 REPO_NAME_PTNFLY_ENG_RELEASE=patternfly-eng-release
 REPO_NAME_PTNFLY_WC=patternfly-webcomponents
-REPO_NAME_RCUE=rcue
 
 # Repo owners
 REPO_OWNER_PTNFLY=patternfly
 REPO_OWNER_PTNFLY_WC=patternfly-webcomponents
-REPO_OWNER_RCUE=redhat-rcue
 
 # Set flag indicating scripts are running against a fork to prevent accidental merging, npm publish, etc.
 if [ -n "$TRAVIS" -a -n "$TRAVIS_REPO_SLUG" ]; then
   REPO_OWNER=`dirname $TRAVIS_REPO_SLUG`
   if ! [ "$REPO_OWNER" = "$REPO_OWNER_PTNFLY" -o \
-         "$REPO_OWNER" = "$REPO_OWNER_PTNFLY_WC" -o \
-         "$REPO_OWNER" = "$REPO_OWNER_RCUE" ]; then
+         "$REPO_OWNER" = "$REPO_OWNER_PTNFLY_WC" ]; then
     REPO_FORK=1
   fi
 fi
@@ -76,7 +72,6 @@ if [ -n "$REPO_FORK" ]; then
   # Set fork owner for repo slugs (i.e., owner_name/repo_name)
   REPO_OWNER_PTNFLY=$REPO_OWNER
   REPO_OWNER_PTNFLY_WC=$REPO_OWNER
-  REPO_OWNER_RCUE=$REPO_OWNER
 
   # Email used to notify users release is available
   EMAIL_PTNFLY=$REPO_OWNER@redhat.com
@@ -100,7 +95,6 @@ REPO_SLUG_PTNFLY_ENG_RELEASE=$REPO_OWNER_PTNFLY/patternfly-eng-release
 REPO_SLUG_PTNFLY_NG=$REPO_OWNER_PTNFLY/patternfly-ng
 REPO_SLUG_PTNFLY_ORG=$REPO_OWNER_PTNFLY/patternfly-org
 REPO_SLUG_PTNFLY_WC=$REPO_OWNER_PTNFLY_WC/patternfly-webcomponents
-REPO_SLUG_RCUE=$REPO_OWNER_RCUE/rcue
 
 # Repo URLs
 REPO_URL_PTNFLY="github.com/$REPO_SLUG_PTNFLY.git"

--- a/scripts/release/_build-next.sh
+++ b/scripts/release/_build-next.sh
@@ -120,7 +120,6 @@ cat <<- EEOOFF
     a       Angular PatternFly
     e       PatternFly Eng Release
     p       PatternFly
-    r       RCUE
 
 EEOOFF
 }
@@ -146,9 +145,6 @@ EEOOFF
       p) PTNFLY=1;
          REPO_SLUG=$REPO_SLUG_PTNFLY;
          SWITCH=p;;
-      r) RCUE=1;
-         REPO_SLUG=$REPO_SLUG_RCUE;
-         SWITCH=r;;
       \?) usage; exit 1;;
     esac
   done
@@ -164,8 +160,6 @@ EEOOFF
   if [ -n "$PTNFLY" -o -n "$PTNFLY_ANGULAR" ]; then
     sh -x $SCRIPT_DIR/_publish-branch.sh -m -b $NEXT_BRANCH
     sh -x $SCRIPT_DIR/_publish-branch.sh -d -b $NEXT_DIST_BRANCH
-  elif [ -n "$RCUE" ]; then
-    sh -x $SCRIPT_DIR/_publish-branch.sh -m -b $NEXT_BRANCH
   else
     sh -x $SCRIPT_DIR/_publish-branch.sh -m
   fi
@@ -183,7 +177,6 @@ EEOOFF
   if [ -z "$SKIP_CHAINED_RELEASE" ]; then
     if [ -n "$PTNFLY" ]; then
       add_bump_tag $REPO_NAME_PTNFLY_ANGULAR $NEXT_BRANCH $NEXT_BRANCH-$REPO_NAME_PTNFLY_ANGULAR
-      add_bump_tag $REPO_NAME_RCUE $NEXT_BRANCH $NEXT_BRANCH-$REPO_NAME_RCUE
     elif [ -n "$PTNFLY_ENG_RELEASE" ]; then
       add_bump_tag $REPO_NAME_PTNFLY $NEXT_BRANCH $NEXT_BRANCH-$REPO_NAME_PTNFLY
     fi

--- a/scripts/release/_build.sh
+++ b/scripts/release/_build.sh
@@ -105,7 +105,7 @@ cat <<- EEOOFF
 
     If a custom Git tag has been created to publish a release, the Git tag will be deleted first. Then, the appropriate
     scripts will be called to bump version numbers and publish the repo. Finally, a custom tag will be created to kick
-    off the release for the Angular PatternFly, PatternFly Org and RCUE repos.
+    off the release for the Angular PatternFly and PatternFly Org repos.
 
     Note: Intended for use with Travis only.
 
@@ -121,7 +121,6 @@ cat <<- EEOOFF
     e       PatternFly Eng Release
     o       PatternFly Org
     p       PatternFly
-    r       RCUE
     w       PatternFly Web Components
     x       Patternfly NG
 
@@ -152,9 +151,6 @@ EEOOFF
       p) PTNFLY=1;
          REPO_SLUG=$REPO_SLUG_PTNFLY;
          SWITCH=p;;
-      r) RCUE=1;
-         REPO_SLUG=$REPO_SLUG_RCUE;
-         SWITCH=r;;
       w) PTNFLY_WC=1;
          REPO_SLUG=$REPO_SLUG_PTNFLY_WC;
          SWITCH=w;;
@@ -200,7 +196,6 @@ EEOOFF
   if [ -z "$SKIP_CHAINED_RELEASE" ]; then
     if [ -n "$PTNFLY" ]; then
       add_bump_tag $REPO_NAME_PTNFLY_ORG $RELEASE_BRANCH $RELEASE_BRANCH-$REPO_NAME_PTNFLY_ORG
-      add_bump_tag $REPO_NAME_RCUE $RELEASE_BRANCH $RELEASE_BRANCH-$REPO_NAME_RCUE
     #elif [ -n "$PTNFLY_ANGULAR" ]; then
     #  add_bump_tag $REPO_NAME_PTNFLY_ORG $RELEASE_BRANCH $RELEASE_BRANCH-$REPO_NAME_PTNFLY_ORG
     elif [ -n "$PTNFLY_ENG_RELEASE" ]; then
@@ -209,7 +204,5 @@ EEOOFF
   fi
 
   # Generate release notes
-  if [ -n "$RCUE" ]; then
-    sh -x $SCRIPT_DIR/_release-notes.sh -v $VERSION -$SWITCH
-  fi
+  sh -x $SCRIPT_DIR/_release-notes.sh -v $VERSION -$SWITCH
 }

--- a/scripts/release/_common.sh
+++ b/scripts/release/_common.sh
@@ -23,10 +23,6 @@ git_setup()
   git remote add $REPO_NAME_PTNFLY_ORG https://$AUTH_TOKEN@github.com/$REPO_SLUG_PTNFLY_ORG.git
   check $? "git add remote failure"
 
-  # Add RCUE as the next remote
-  git remote rm $REPO_NAME_RCUE
-  git remote add $REPO_NAME_RCUE https://$AUTH_TOKEN@github.com/$REPO_SLUG_RCUE.git
-  check $? "git add remote failure"
 }
 
 # Clone local repo and checkout branch

--- a/scripts/release/notify-next.sh
+++ b/scripts/release/notify-next.sh
@@ -4,7 +4,7 @@ default()
 {
   PATH=/usr/local/bin:/usr/bin:/bin:$PATH
   export PATH
-  
+
   SCRIPT=`basename $0`
   SCRIPT_DIR=`dirname $0`
   SCRIPT_DIR=`cd $SCRIPT_DIR; pwd`
@@ -58,7 +58,7 @@ EEOOFF
 usage()
 {
 cat <<- EEOOFF
-    This script will send a PF 'next' release notice to the PatternFly, Angular PatternFly, and RCUE mailling lists.
+    This script will send a PF 'next' release notice to the PatternFly and Angular PatternFly mailling lists.
 
     Note: You must configure your system to tell it where to send email. If you haven't done so, see:
     http://codana.me/2014/11/23/sending-gmail-from-os-x-yosemite-terminal
@@ -71,7 +71,6 @@ cat <<- EEOOFF
     h       Display this message (default)
     a       Angular PatternFly
     p       PatternFly
-    r       RCUE
     v       The version number (e.g., 3.15.0)
 
     SPECIAL OPTIONS:
@@ -99,9 +98,6 @@ EEOOFF
       p) EMAIL="$EMAIL_PTNFLY";
          SUBJECT="PatternFly";
          REPO_SLUG=$REPO_SLUG_PTNFLY;;
-      r) EMAIL="$EMAIL_RCUE";
-         SUBJECT="RCUE";
-         REPO_SLUG=$REPO_SLUG_RCUE;;
       v) VERSION=$OPTARG;;
       \?) usage; exit 1;;
     esac

--- a/scripts/release/notify.sh
+++ b/scripts/release/notify.sh
@@ -4,7 +4,7 @@ default()
 {
   PATH=/usr/local/bin:/usr/bin:/bin:$PATH
   export PATH
-  
+
   SCRIPT=`basename $0`
   SCRIPT_DIR=`dirname $0`
   SCRIPT_DIR=`cd $SCRIPT_DIR; pwd`
@@ -68,7 +68,7 @@ fetch_notes()
 usage()
 {
 cat <<- EEOOFF
-    This script will send a release notice to the PatternFly, Angular PatternFly, and RCUE mailling lists.
+    This script will send a release notice to the PatternFly and Angular PatternFly mailling lists.
 
     After publishing a release notes via GitHub, the script will pull the markup using GitHub APIs. The markup is then
     added to the body of the outgoing message.
@@ -84,7 +84,6 @@ cat <<- EEOOFF
     h       Display this message (default)
     a       Angular PatternFly
     p       PatternFly
-    r       RCUE
     v       The version number (e.g., 3.15.0)
 
     SPECIAL OPTIONS:
@@ -112,9 +111,6 @@ EEOOFF
       p) EMAIL="$EMAIL_PTNFLY";
          SUBJECT="PatternFly";
          REPO_SLUG=$REPO_SLUG_PTNFLY;;
-      r) EMAIL="$EMAIL_RCUE";
-         SUBJECT="RCUE";
-         REPO_SLUG=$REPO_SLUG_RCUE;;
       v) VERSION=$OPTARG;;
       \?) usage; exit 1;;
     esac

--- a/scripts/release/publish-npm.sh
+++ b/scripts/release/publish-npm.sh
@@ -68,7 +68,6 @@ cat <<- EEOOFF
     a       Angular PatternFly
     e       PatternFly Eng Release
     p       PatternFly
-    r       RCUE
     w       PatternFly Web Components
     x       PatternFly NG
 
@@ -101,9 +100,6 @@ EEOOFF
       p) BUILD_DIR=$TMP_DIR/patternfly;
          REPO_SLUG=$REPO_SLUG_PTNFLY;;
       s) SKIP_SETUP=1;;
-      r) BRANCH=$RELEASE_BRANCH
-         BUILD_DIR=$TMP_DIR/rcue;
-         REPO_SLUG=$REPO_SLUG_RCUE;;
       w) BUILD_DIR=$TMP_DIR/patternfly-webcomponents;
          REPO_SLUG=$REPO_SLUG_PTNFLY_WC;;
       x) BUILD_DIR=$TMP_DIR/patternfly-ng;

--- a/scripts/release/release-all.sh
+++ b/scripts/release/release-all.sh
@@ -42,7 +42,7 @@ cat <<- EEOOFF
     When the release is complete, the custom Git tag is removed from GitHub. The custom tag is created using a clone so
     it won't persist in your local repo.
 
-    If the release is successful, RCUE, Angular PatternFly, and PatternFly Org will be released as well. This is done
+    If the release is successful, Angular PatternFly and PatternFly Org will be released as well. This is done
     by creating a Git tag for the next repo to be built.
 
     If 3.15.0 is provided as a version number; for example, the release will be tagged as v3.15.0.
@@ -61,7 +61,6 @@ cat <<- EEOOFF
     e       PatternFly Eng Release (DISABLED for semantic release)
     o       PatternFly Org
     p       PatternFly (DISABLED for semantic release)
-    r       RCUE
     v       The version number (e.g., 3.15.0)
     w       PatternFly Web Components (DISABLED for semantic release)
     x       Patternfly NG (DISABLED for semantic release)
@@ -92,7 +91,6 @@ EEOOFF
       n) RELEASE_NEXT=1;;
       o) PTNFLY_ORG=1;;
       p) PTNFLY=1; usage; exit1;; # DISABLED
-      r) RCUE=1;;
       s) SKIP_CHAINED_RELEASE=1;;
       v) VERSION=$OPTARG;;
       w) PTNFLY_WC=1; usage; exit1;; # DISABLED
@@ -122,10 +120,6 @@ EEOOFF
     BUILD_DIR=$TMP_DIR/patternfly
     REPO_SLUG=$REPO_SLUG_PTNFLY
   fi
-  if [ -n "$RCUE" ]; then
-    BUILD_DIR=$TMP_DIR/rcue
-    REPO_SLUG=$REPO_SLUG_RCUE
-  fi
   if [ -n "$PTNFLY_WC" ]; then
     BUILD_DIR=$TMP_DIR/patternfly-webcomponents
     REPO_SLUG=$REPO_SLUG_PTNFLY_WC
@@ -142,7 +136,7 @@ EEOOFF
 
   # Release PF Next branches
   if [ -n "$RELEASE_NEXT" ]; then
-    if [ -n "$PTNFLY" -o -n "$PTNFLY_ANGULAR" -o -n "$RCUE" ]; then
+    if [ -n "$PTNFLY" -o -n "$PTNFLY_ANGULAR" ]; then
       BRANCH=$NEXT_BRANCH
     fi
   fi

--- a/scripts/release/release.sh
+++ b/scripts/release/release.sh
@@ -59,9 +59,6 @@ bump_bower()
 
     sed "s|\"version\":.*|\"version\": \"$VERSION\",|" $BOWER_JSON | \
     sed "s|\"patternfly\":.*|\"patternfly\": \"$PKG_PTNFLY\",|" > $BOWER_JSON.tmp
-  elif [ -n "$RCUE" ]; then
-    sed "s|\"version\":.*|\"version\": \"$VERSION\",|" $BOWER_JSON | \
-    sed "s|\"patternfly\":.*|\"patternfly\": \"$PKG_PTNFLY\"|" > $BOWER_JSON.tmp
   fi
   check $? "Version bump failure"
 
@@ -110,13 +107,6 @@ bump_package()
 
     sed "s|\"version\":.*|\"version\": \"$VERSION\",|" $PACKAGE_JSON | \
     sed "s|\"patternfly\": \".*|\"patternfly\": \"$PKG_PTNFLY\",|" > $PACKAGE_JSON.tmp
-  elif [ -n "$RCUE" ]; then
-    #sed "s|\"version\":.*|\"version\": \"$VERSION\",|" $PACKAGE_JSON | \
-    #sed "s|\"patternfly\":.*|\"patternfly\": \"$PKG_PTNFLY\"|" | \
-    #sed "s|\"patternfly-eng-release\":.*|\"patternfly-eng-release\": \"$PKG_PTNFLY_ENG_RELEASE\"|" > $PACKAGE_JSON.tmp
-
-    sed "s|\"version\":.*|\"version\": \"$VERSION\",|" $PACKAGE_JSON | \
-    sed "s|\"patternfly\":.*|\"patternfly\": \"$PKG_PTNFLY\"|" > $PACKAGE_JSON.tmp
   elif [ -n "$PTNFLY_ENG_RELEASE" ]; then
     sed "s|\"version\":.*|\"version\": \"$VERSION\",|" $PACKAGE_JSON > $PACKAGE_JSON.tmp
   elif [ -n "$PTNFLY_WC" ]; then
@@ -250,7 +240,6 @@ cat <<- EEOOFF
     e       PatternFly Eng Release
     o       PatternFly Org
     p       PatternFly
-    r       RCUE
     v       The version number (e.g., 3.15.0)
     w       PatternFly Web Components
     x       Patternfly NG
@@ -314,7 +303,6 @@ verify()
       n) BRANCH_DIST=$NEXT_DIST_BRANCH;;
       o) PTNFLY_ORG=1;;
       p) PTNFLY=1;;
-      r) RCUE=1;;
       s) SKIP_SETUP=1;;
       v) VERSION=$OPTARG;
          BUMP_BRANCH=bump-v$VERSION;;
@@ -348,11 +336,6 @@ verify()
     BUILD_DIR=$TMP_DIR/patternfly
     REPO_SLUG=$REPO_SLUG_PTNFLY
     VERIFY_DIR="$TMP_DIR/patternfly-verify"
-  fi
-  if [ -n "$RCUE" ]; then
-    BUILD_DIR=$TMP_DIR/rcue
-    REPO_SLUG=$REPO_SLUG_RCUE
-    VERIFY_DIR="$TMP_DIR/rcue-verify"
   fi
   if [ -n "$PTNFLY_WC" ]; then
     BUILD_DIR=$TMP_DIR/patternfly-webcomponents
@@ -389,7 +372,7 @@ verify()
   build_test
   regression_test
 
-  if [ -n "$PTNFLY" -o -n "$PTNFLY_ANGULAR" -o -n "$RCUE" -o -n "$PTNFLY_WC" ]; then
+  if [ -n "$PTNFLY" -o -n "$PTNFLY_ANGULAR" -o -n "$PTNFLY_WC" ]; then
     shrinkwrap
   fi
 

--- a/scripts/semantic-release/_common.sh
+++ b/scripts/semantic-release/_common.sh
@@ -12,10 +12,6 @@ git_setup()
   git remote add $REPO_NAME_PTNFLY_ORG https://$AUTH_TOKEN@github.com/$REPO_SLUG_PTNFLY_ORG.git
   check $? "git add remote failure"
 
-  # Add RCUE as the next remote
-  git remote rm $REPO_NAME_RCUE
-  git remote add $REPO_NAME_RCUE https://$AUTH_TOKEN@github.com/$REPO_SLUG_RCUE.git
-  check $? "git add remote failure"
 }
 
 # Check prerequisites before continuing

--- a/scripts/semantic-release/_release-all.sh
+++ b/scripts/semantic-release/_release-all.sh
@@ -81,7 +81,6 @@ cat <<- EEOOFF
     OPTIONS:
     h       Display this message (default)
     o       PatternFly Org
-    r       RCUE
 
 EEOOFF
 }
@@ -100,8 +99,6 @@ EEOOFF
       h) usage; exit 0;;
       o) PTNFLY_ORG=1;
          SWITCH=-o;;
-      r) RCUE=1;
-         SWITCH=-r;;
       \?) usage; exit 1;;
     esac
   done
@@ -111,9 +108,6 @@ EEOOFF
 
   if [ -n "$PTNFLY_ORG" ]; then
     add_bump_tag $REPO_NAME_PTNFLY_ORG $RELEASE_BRANCH $RELEASE_BRANCH-$REPO_NAME_PTNFLY_ORG
-  fi
-  if [ -n "$RCUE" ]; then
-    add_bump_tag $REPO_NAME_RCUE $RELEASE_BRANCH $RELEASE_BRANCH-$REPO_NAME_RCUE
   fi
 
   # Restore local branch for other scripts

--- a/scripts/semantic-release/_release-latest.sh
+++ b/scripts/semantic-release/_release-latest.sh
@@ -34,7 +34,6 @@ cat <<- EEOOFF
     OPTIONS:
     h       Display this message (default)
     o       PatternFly Org
-    r       RCUE
 
 EEOOFF
 }
@@ -53,8 +52,6 @@ EEOOFF
       h) usage; exit 0;;
       o) PTNFLY_ORG=1;
          SWITCH=-o;;
-      r) RCUE=1;
-         SWITCH=-r;;
       \?) usage; exit 1;;
     esac
   done


### PR DESCRIPTION
This removes all references to RCUE, as it is now part of the core PatternFly release.