### PR TITLE
bump node version in travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ notifications:
   email: false
 
 node_js:
-  - '6'
+  - '8'
 
 install: true
 


### PR DESCRIPTION
The latest semantic release requires node 8+