### PR TITLE
Remove shrinkwrap

### DIFF
--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -144,14 +144,16 @@ git_setup()
 
 # Shrink wrap npm and run vulnerability test
 #
+# The recommended use-case for npm-shrinkwrap.json is applications deployed through the publishing process on the
+# registry: for example, daemons and command-line tools intended as global installs or devDependencies. It's strongly
+# discouraged for library authors to publish this file, since that would prevent end users from having control over
+# transitive dependency updates.
+#
+# See https://docs.npmjs.com/files/shrinkwrap.json
 shrinkwrap()
 {
   echo "*** Shrink wrapping $SHRINKWRAP_JSON"
   cd $BUILD_DIR
-
-  if [ -s "$PACKAGE_LOCK_JSON" -o -n "$PTNFLY_ENG_RELEASE" ]; then
-    return
-  fi
 
   # Only include production dependencies with shrinkwrap
   npm prune --production

--- a/scripts/release/release.sh
+++ b/scripts/release/release.sh
@@ -389,9 +389,12 @@ verify()
   build_test
   regression_test
 
-  if [ -n "$PTNFLY" -o -n "$PTNFLY_ANGULAR" -o -n "$RCUE" -o -n "$PTNFLY_WC" ]; then
-    shrinkwrap
-  fi
+  # It's strongly discouraged for library authors to publish shrinkwrap.json, since that would prevent end users from
+  # having control over transitive dependency updates. See https://docs.npmjs.com/files/shrinkwrap.json
+  #
+  # if [ -n "$PTNFLY" -o -n "$PTNFLY_ANGULAR" -o -n "$RCUE" -o -n "$PTNFLY_WC" ]; then
+  #  shrinkwrap
+  # fi
 
   commit # Changes must be committed prior to bower verify step
   verify $VERIFY_DIR $BUILD_DIR

--- a/scripts/semantic-release/_release.sh
+++ b/scripts/semantic-release/_release.sh
@@ -131,9 +131,12 @@ verify()
   $SCRIPT_DIR/_regression-test.sh
   check $? "Regression test failure"
 
-  if [ -n "$PTNFLY" -o -n "$PTNFLY_ANGULAR" ]; then
-    shrinkwrap
-  fi
+  # It's strongly discouraged for library authors to publish shrinkwrap.json, since that would prevent end users from
+  # having control over transitive dependency updates. See https://docs.npmjs.com/files/shrinkwrap.json
+  #
+  # if [ -n "$PTNFLY" -o -n "$PTNFLY_ANGULAR" ]; then
+  #  shrinkwrap
+  # fi
 
   verify
   publish_branch


### PR DESCRIPTION
The recommended use-case for npm-shrinkwrap.json is applications deployed through the publishing process on the registry: for example, daemons and command-line tools intended as global installs or devDependencies. It's strongly discouraged for library authors to publish this file, since that would prevent end users from having control over transitive dependency updates.

See https://docs.npmjs.com/files/shrinkwrap.json