### PR TITLE
fix(build): skip master-dist build in favor of gh-pages

### DIFF
--- a/scripts/semantic-release/_release.sh
+++ b/scripts/semantic-release/_release.sh
@@ -139,5 +139,9 @@ verify()
   # fi
 
   verify
-  publish_branch
+
+  # Skip master-dist build in favor of gh-pages -- publish only for forked repos
+  if [ "$TRAVIS_REPO_SLUG" != "$REPO_SLUG_PTNFLY_NG" ]; then
+    publish_branch
+  fi
 }


### PR DESCRIPTION
We only need to build master-dist only for forked repos