### PR TITLE
Removed shrinkwrap for patternfly and angular-patternfly

### DIFF
--- a/scripts/release/release.sh
+++ b/scripts/release/release.sh
@@ -392,9 +392,9 @@ verify()
   # It's strongly discouraged for library authors to publish shrinkwrap.json, since that would prevent end users from
   # having control over transitive dependency updates. See https://docs.npmjs.com/files/shrinkwrap.json
   #
-  if [ -n "$PTNFLY" -o -n "$PTNFLY_ANGULAR" -o -n "$RCUE" -o -n "$PTNFLY_WC" ]; then
-    shrinkwrap
-  fi
+  #if [ -n "$PTNFLY" -o -n "$PTNFLY_ANGULAR" -o -n "$RCUE" -o -n "$PTNFLY_WC" ]; then
+  #  shrinkwrap
+  #fi
 
   commit # Changes must be committed prior to bower verify step
   verify $VERIFY_DIR $BUILD_DIR

--- a/scripts/semantic-release/_release.sh
+++ b/scripts/semantic-release/_release.sh
@@ -134,9 +134,9 @@ verify()
   # It's strongly discouraged for library authors to publish shrinkwrap.json, since that would prevent end users from
   # having control over transitive dependency updates. See https://docs.npmjs.com/files/shrinkwrap.json
   #
-  if [ -n "$PTNFLY" -o -n "$PTNFLY_ANGULAR" ]; then
-    shrinkwrap
-  fi
+  #if [ -n "$PTNFLY" -o -n "$PTNFLY_ANGULAR" ]; then
+  #  shrinkwrap
+  #fi
 
   verify
   publish_branch


### PR DESCRIPTION
During our "coordinating across repos" meeting, we decided to follow the npm recommendation and not publish a shrinkwrap file.

"It's strongly discouraged for library authors to publish shrinkwrap.json, since that would prevent end users from having control over transitive dependency updates." See https://docs.npmjs.com/files/shrinkwrap.json